### PR TITLE
add functionality to support multiple instances in the same page

### DIFF
--- a/FroalaEditorWidget.php
+++ b/FroalaEditorWidget.php
@@ -2,7 +2,7 @@
 
 namespace froala\froalaeditor;
 
-use Yii;
+use yii;
 use yii\helpers\Html;
 use yii\helpers\Json;
 use yii\widgets\InputWidget;
@@ -12,13 +12,31 @@ class FroalaEditorWidget extends InputWidget
     const PLUGIN_NAME = 'FroalaEditor';
 
     /**
-     * FroalaEditor Plugins
      * @var array
+     * Plugins to be included, leave empty to load all plugins
+     * <pre>sample input:
+     * [
+     *      //specify only needed forala plugins (local files)
+     *      'url',
+     *      'align',
+     *      'char_counter',
+     *       ...
+     *      //override default files for a specific plugin
+     *      'table' => [
+     *              'css' => '<new css file url>'
+     *          ],
+     *      //include custom plugin
+     *      'my_plugin' => [
+     *              'js' => '<js file url>' // required
+     *              'css' => '<css file url>' // optional
+     *          ],
+     *      ...
+     * ]
      */
     public $clientPlugins;
 
     /**
-     * Exclude listed plugins
+     * Remove these plugins from this list of plugins in clientPlugins
      * @var array
      */
     public $excludedPlugins;
@@ -62,26 +80,25 @@ class FroalaEditorWidget extends InputWidget
     {
         $view = $this->getView();
         $this->initClientOptions();
-
-        FroalaEditorAsset::$clientPlugins = $this->clientPlugins;
-        FroalaEditorAsset::$excludedPlugins = $this->excludedPlugins;
         $asset = FroalaEditorAsset::register($view);
+        $asset->registerClientPlugins($this->clientPlugins, $this->excludedPlugins);
 
         //theme
         $themeType = isset($this->clientOptions['theme']) ? $this->clientOptions['theme'] : 'default';
         if ($themeType != 'default') {
-            $view->registerCssFile($asset->baseUrl . "/css/themes/{$themeType}.css", ['depends' => '\froala\froalaeditor\FroalaEditorAsset']);
+            $view->registerCssFile("{$asset->baseUrl}/css/themes/{$themeType}.css", ['depends' => '\froala\froalaeditor\FroalaEditorAsset']);
         }
         //language
         $langType = isset($this->clientOptions['language']) ? $this->clientOptions['language'] : 'en_gb';
         if ($langType != 'es_gb') {
-            $view->registerJsFile($asset->baseUrl . "/js/languages/{$langType}.js", ['depends' => '\froala\froalaeditor\FroalaEditorAsset']);
+            $view->registerJsFile("{$asset->baseUrl}/js/languages/{$langType}.js", ['depends' => '\froala\froalaeditor\FroalaEditorAsset']);
         }
 
-        $options = empty($this->options) ? '' : Json::encode($this->options);
         $id = $this->options['id'];
 
-        $jsOptions = Json::encode($this->clientOptions);
+        $jsOptions = array_merge($this->clientOptions, $this->clientPlugins ? ['pluginsEnabled' => $this->clientPlugins] : []);
+        $jsOptions = Json::encode($jsOptions);
+
         $view->registerJs("\$('#$id').froalaEditor($jsOptions);");
     }
 


### PR DESCRIPTION
added functionality to support multiple instances in the same page, the main assets will be registered wherever widget used, in every new instance the engine will add the requested plugins to the active asset object.
plugins for every instance will be determined using '**pluginsEnabled**'  option as it identified in the property '**clientPlugins**'