### PR TITLE
fix can't enable custom plugin

### DIFF
--- a/src/FroalaEditorAsset.php
+++ b/src/FroalaEditorAsset.php
@@ -59,11 +59,13 @@ class FroalaEditorAsset extends AssetBundle
      */
     public function registerClientPlugins($clientPlugins, $excludedPlugins)
     {
+        $pluginNames = [];
         if (is_array($clientPlugins)) {
             if (ArrayHelper::isIndexed($clientPlugins, true)) {
                 // sequential array = list of plugins to be included
                 // use default configurations for every plugin
                 $this->registerPlugins($clientPlugins);
+                $pluginNames = array_values($clientPlugins);
             } else {
                 // associative array = custom plugins and options included
                 foreach ($clientPlugins as $key => $value) {
@@ -96,11 +98,13 @@ class FroalaEditorAsset extends AssetBundle
                             }
                         }
                     }
+                    $pluginNames[] = $pluginName;
                 }
             }
         } else {
             $this->registerPlugins(array_diff($this->froalaPlugins, $excludedPlugins ?: []), false, true);
         }
+        return $pluginNames;
     }
 
     /**

--- a/src/FroalaEditorWidget.php
+++ b/src/FroalaEditorWidget.php
@@ -39,7 +39,7 @@ class FroalaEditorWidget extends InputWidget
      * Remove these plugins from this list plugins, this option overrides 'clientPlugins'
      * @var array
      */
-    public $excludedPlugins;
+    public $excludedPlugins = [];
 
     /**
      * FroalaEditor Options
@@ -80,7 +80,7 @@ class FroalaEditorWidget extends InputWidget
     {
         $view = $this->getView();
         $asset = FroalaEditorAsset::register($view);
-        $asset->registerClientPlugins($this->clientPlugins, $this->excludedPlugins);
+        $plugin_names = $asset->registerClientPlugins($this->clientPlugins, $this->excludedPlugins);
 
         //theme
         $themeType = isset($this->clientOptions['theme']) ? $this->clientOptions['theme'] : 'default';
@@ -97,7 +97,7 @@ class FroalaEditorWidget extends InputWidget
         if (empty($this->clientPlugins)) {
             $pluginsEnabled = false;
         } else {
-            $pluginsEnabled = array_diff($this->clientPlugins, $this->excludedPlugins ?: []);
+            $pluginsEnabled = array_diff($plugin_names, $this->excludedPlugins ?: []);
         }
         if(!empty($pluginsEnabled)){
             foreach($pluginsEnabled as $key =>$item){


### PR DESCRIPTION
I got an error when trying to enable a custom plugin.  my clientPlugin array looked something like this:

```
[
  'my_custom_plugin' => ['css' => 'some/url.css', 'js' => 'some/url.js'], 
  'align', 
  'code_beautifier', 
  'code_view', 
  ... etc ...
]
```
First I got an error "in_array() expects parameter 2 to be array, null given" on line 163 of FroalaEditorAsset - so I'm setting $excludedPlugins = [] by default (in FroalaEditorWidget).

Also, the array_diff on line 100 of FroalaEditorWidget.php was skipping the custom plugin, and it wasn't getting enabled because of the mixed structure of the clientPlugin array.  So this pull request creates a separate array of plugin names that will include the custom plugin in the array_diff.